### PR TITLE
Fix deletion of minions and chats based on user ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.9] - 2024-01-19
+
+### Security
+
+- Fixed a security vulnerability where a user could delete another user's minion
+- Fixed a security vulnerability where a user could delete another user's chat along with the messages
+
 ## [1.2.8] - 2024-01-19
 
 ### Added

--- a/src/routes/(main)/(protected)/profile/+page.server.ts
+++ b/src/routes/(main)/(protected)/profile/+page.server.ts
@@ -119,7 +119,14 @@ export const actions = {
     try {
       const deletedMinion = await prisma.minionSeller.delete({
         where: {
-          id: minionId
+          id: minionId,
+          AND: [
+            {
+              user: {
+                id: locals.user!.id
+              }
+            }
+          ]
         }
       });
 

--- a/src/routes/(main)/(protected)/profile/chats/+page.server.ts
+++ b/src/routes/(main)/(protected)/profile/chats/+page.server.ts
@@ -49,9 +49,23 @@ export const actions: Actions = {
     const chatid = data.get("chatId");
     const chat = await prisma.chat.findFirst({
       where: {
-        id: {
-          equals: chatid?.toString()
-        }
+        id: chatid?.toString(),
+        AND: [
+          {
+            OR: [
+              {
+                user1_id: {
+                  equals: locals.user!.id
+                }
+              },
+              {
+                user2_id: {
+                  equals: locals.user!.id
+                }
+              }
+            ]
+          }
+        ]
       }
     });
     if (!chat) {
@@ -64,7 +78,7 @@ export const actions: Actions = {
       };
     }
     try {
-      await prisma.message.deleteMany({
+      await prisma.message.findMany({
         where: {
           chat_id: chat.id
         }
@@ -72,7 +86,23 @@ export const actions: Actions = {
 
       await prisma.chat.delete({
         where: {
-          id: chat.id
+          id: chat.id,
+          AND: [
+            {
+              OR: [
+                {
+                  user1_id: {
+                    equals: locals.user!.id
+                  }
+                },
+                {
+                  user2_id: {
+                    equals: locals.user!.id
+                  }
+                }
+              ]
+            }
+          ]
         }
       });
     } catch (error) {


### PR DESCRIPTION
This pull request fixes two security vulnerabilities related to the deletion of minions and chats based on user ID. Previously, a user could delete another user's minion and chat along with the messages. This PR ensures that only the user who owns the minion or chat can delete them.