### PR TITLE
Update og:image URLs to force a refresh of the image cache

### DIFF
--- a/src/routes/(main)/+layout.svelte
+++ b/src/routes/(main)/+layout.svelte
@@ -12,8 +12,8 @@
   <meta property="og:url" content="https://minionah.com" />
   <meta property="og:title" content="MinionAH — The Auction House for Hypixel SkyBlock Minions" />
   <meta property="og:description" content="Buy and sell Hypixel SkyBlock minions easily on MinionAH. Explore a seamless marketplace with a beautiful interface for minion trading." />
-  <meta property="og:image" content="https://minionah.com/assets/images/ogBanner.png" />
-  <meta property="og:image:secure_url" content="https://minionah.com/assets/images/ogBanner.png" />
+  <meta property="og:image" content="https://minionah.com/assets/images/ogBanner.png?v=2" />
+  <meta property="og:image:secure_url" content="https://minionah.com/assets/images/ogBanner.png?v=2" />
   <meta property="og:image:alt" content="MinionAH" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -26,6 +26,6 @@
   <meta property="twitter:url" content="https://minionah.com" />
   <meta property="twitter:title" content="MinionAH" />
   <meta property="twitter:description" content="Buy and sell Hypixel SkyBlock minions easily on MinionAH. Explore a seamless marketplace with a beautiful interface for minion trading." />
-  <meta property="twitter:image" content="https://minionah.com/assets/images/ogBanner.png" />
+  <meta property="twitter:image" content="https://minionah.com/assets/images/ogBanner.png?v=2" />
 </svelte:head>
 <slot />

--- a/src/routes/api/craftcost/docs/+page.svelte
+++ b/src/routes/api/craftcost/docs/+page.svelte
@@ -62,7 +62,7 @@
   <meta name="twitter:creator" content="@iDarthGigi" />
   <meta property="og:title" content="RCC API Documentation — MinionAH" />
   <meta property="og:description" content="Since NEU does not provide a public API for their (raw) craft cost feature, we decided to create our own. We have created a public API that will calculate the (raw) craft cost of any Hypixel SkyBlock item. This API is available for everyone to use in their own projects." />
-  <meta property="og:image" content="https://minionah.com/assets/images/ogBanner.png" />
+  <meta property="og:image" content="https://minionah.com/assets/images/ogBanner.png?v=2" />
   <meta property="og:url" content="https://minionah.com/api/craftcost/docs" />
   <meta property="og:site_name" content="MinionAH" />
   <meta property="og:locale" content="en_US" />


### PR DESCRIPTION
This pull request updates the og:image URLs in the HTML files to include a version parameter (?v=2) in order to force a refresh of the image cache. This ensures that the latest version of the images is always displayed when sharing the website on social media platforms.