### PR TITLE
Add dataType option to form validation and set fcmToken in notifications form

### DIFF
--- a/src/routes/(main)/(protected)/profile/settings/notifications/notifications-form.svelte
+++ b/src/routes/(main)/(protected)/profile/settings/notifications/notifications-form.svelte
@@ -30,6 +30,7 @@
 
   const form = superForm(data, {
     validators: zodClient(notificationsFormSchema),
+    dataType: "json",
     resetForm: false
   });
   const { form: formData, enhance } = form;
@@ -51,6 +52,7 @@
       fcmToken = await getToken(messaging, {
         serviceWorkerRegistration: await navigator.serviceWorker.ready
       });
+      $formData.fcmToken = fcmToken;
       deviceRadioDisabled = false;
       allRadioDisabled = !hasEmail;
     } else if (permission === "denied" || permission === "default") {


### PR DESCRIPTION
This pull request adds the `dataType` option to the form validation in the notifications form. It also sets the `fcmToken` in the form data.