### PR TITLE
Refactor form validation and data handling in signup password page

### DIFF
--- a/src/routes/(main)/signup/(protected)/password/+page.server.ts
+++ b/src/routes/(main)/signup/(protected)/password/+page.server.ts
@@ -6,8 +6,13 @@ import type { Actions, PageServerLoad } from "./$types";
 import { formSchema } from "./schema";
 
 export const load = (async ({ locals }) => {
-  const superValidatedFormSchema = await superValidate(zod(formSchema));
-  superValidatedFormSchema.data.username = locals.user!.username;
+  console.log(locals.user!.username);
+  const superValidatedFormSchema = await superValidate(
+    {
+      username: locals.user!.username
+    },
+    zod(formSchema)
+  );
 
   return {
     form: superValidatedFormSchema

--- a/src/routes/(main)/signup/(protected)/password/+page.svelte
+++ b/src/routes/(main)/signup/(protected)/password/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { page } from "$app/stores";
   import * as AlertDialog from "$lib/components/ui/alert-dialog";
   import * as Form from "$lib/components/ui/form";
   import { Input } from "$lib/components/ui/input";
@@ -8,22 +7,17 @@
   import { zodClient } from "sveltekit-superforms/adapters";
   import { formSchema, type FormSchema } from "./schema";
 
-  export let data: SuperValidated<Infer<FormSchema>>;
+  export let data;
+  const dataForm: SuperValidated<Infer<FormSchema>> = data.form;
 
-  const form = superForm(data, {
-    warnings: { duplicateId: false },
-    validators: zodClient(formSchema),
-    dataType: "json"
+  const form = superForm(dataForm, {
+    validators: zodClient(formSchema)
   });
 
   const { form: formData, enhance, message } = form;
 
   let passwordConfirmInputIsValid = false;
   let submitting = false;
-
-  $: if ($page.form) {
-    submitting = false;
-  }
 </script>
 
 <form


### PR DESCRIPTION
This pull request refactors the form validation and data handling in the signup password page. It updates the code to use the `superValidate` function and improves the handling of form data. The changes include updating the `superValidatedFormSchema` to include the `username` from the `locals.user` object, and refactoring the form handling logic in the Svelte component.