### PR TITLE
Add worker-src directive to csp in svelte.config.js

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -15,6 +15,7 @@ const config = {
     csp: {
       directives: {
         "script-src": ["self", "https://*.vercel-scripts.com", "https://*.vercel.app", "https://*.pusher.com", "sha256-y2WkUILyE4eycy7x+pC0z99aZjTZlWfVwgUAfNc1sY8="],
+        "worker-src": ["self", "blob:", "https://*.minionah.com"],
         "img-src": ["self", "data:", "https://*.vercel.app", "https://*.vercel-scripts.com", "https://*.imgur.com", "https://*.imgbb.com", "https://*.vgy.me", "https://*.gyazo.com", "https://*.prnt.sc", "https://*.prntscr.com", "https://*.tenor.com", "https://*.giphy.com", "https://*.gfycat.com", "https://*.discordapp.net", "https://*.discordapp.com", "https://*.discord.com", "https://*.minionah.com", "https://*.cloudinary.com"],
         "style-src": ["self", "unsafe-inline"]
       },


### PR DESCRIPTION
This pull request adds the "worker-src" directive to the Content Security Policy (CSP) in the svelte.config.js file. This allows the specified sources to be used as web workers in the application.