### PR TITLE
Fix user profile breadcrumb links

### DIFF
--- a/src/lib/components/card/cardminion.svelte
+++ b/src/lib/components/card/cardminion.svelte
@@ -49,7 +49,7 @@
   </div>
   {#if isHome}
     <div class="flex h-10">
-      <a href={`${minion.user.username}/chat`} data-sveltekit-preload-data="off" class="relative flex h-full w-full items-center justify-center overflow-hidden rounded-b-lg font-medium text-primary transition-all duration-300">
+      <a href={`/user/${minion.user.username}/chat`} data-sveltekit-preload-data="off" class="relative flex h-full w-full items-center justify-center overflow-hidden rounded-b-lg font-medium text-primary transition-all duration-300">
         <div class="group peer relative z-10 flex h-full w-full min-w-0 flex-shrink-0 flex-nowrap items-center justify-center text-nowrap rounded-full px-2 py-0.5 text-xs font-medium text-primary transition-all duration-300 group-hover:scale-125 group-hover:text-muted">
           <div class="inline-block">Buy&nbsp;</div>
           <div class="inline-block w-0 max-w-fit flex-nowrap overflow-hidden text-nowrap transition-[width] duration-1000 group-hover:w-full">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -34,7 +34,7 @@
   }
 
   page.subscribe((value) => {
-    const urls = value.url.pathname.split("/").filter((url) => url !== "user" && Boolean(url));
+    const urls = value.url.pathname.split("/").filter((url) => Boolean(url));
     paths.set(urls);
   });
 
@@ -105,11 +105,19 @@
       <Breadcrumb.Item>
         <Breadcrumb.Link href="/">Home</Breadcrumb.Link>
       </Breadcrumb.Item>
-      {#each $paths as path}
-        <Breadcrumb.Separator />
-        <Breadcrumb.Item>
-          <Breadcrumb.Link href={`/${path}`} class="capitalize">{path}</Breadcrumb.Link>
-        </Breadcrumb.Item>
+      {#each $paths as path, index}
+        {#if path !== "user"}
+          <Breadcrumb.Separator />
+          <Breadcrumb.Item>
+            {#if $paths[index - 1] === "user"}
+              <Breadcrumb.Link href={`/user/${path}`} class="capitalize">{path}</Breadcrumb.Link>
+            {:else if $paths[index - 2] === "user"}
+              <Breadcrumb.Link href={`/user/${$paths[index - 1]}/${path}`} class="capitalize">{path}</Breadcrumb.Link>
+            {:else}
+              <Breadcrumb.Link href={`/${path}`} class="capitalize">{path}</Breadcrumb.Link>
+            {/if}
+          </Breadcrumb.Item>
+        {/if}
       {/each}
     </Breadcrumb.List>
   </Breadcrumb.Root>


### PR DESCRIPTION
This pull request fixes the breadcrumb links in the user profile page. Previously, the links were not correctly generated when the user's username was part of the URL. This PR updates the code to generate the correct links for the user profile breadcrumb.