### PR TITLE
Update cron scripts to capture check-in status during cleanup and minionprice cron jobs

### DIFF
--- a/src/routes/api/internal/crons/cleanup/+server.ts
+++ b/src/routes/api/internal/crons/cleanup/+server.ts
@@ -1,10 +1,32 @@
 import { CRON_SECRET } from "$env/static/private";
 import { lucia } from "$lib/server/lucia";
+import * as Sentry from "@sentry/sveltekit";
 import { json } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 
+
+const checkInId = Sentry.captureCheckIn(
+  {
+    monitorSlug: 'cleanup-cron',
+    status: 'in_progress',
+  },
+  {
+    schedule: {
+      type: 'crontab',
+      value: '0 12 * * *',
+    },
+    checkinMargin: 0.2,
+    maxRuntime: 0.2,
+    timezone: 'Etc/UTC',
+  });
+
 export const GET: RequestHandler = async ({ request, fetch }) => {
   if (!CRON_SECRET || request.headers.get("Authorization") !== `Bearer ${CRON_SECRET}`) {
+    Sentry.captureCheckIn({
+      checkInId,
+      monitorSlug: 'cleanup-cron',
+      status: 'error',
+    });
     return json(
       { success: false, error: "Invalid Authorization header" },
       {
@@ -16,9 +38,19 @@ export const GET: RequestHandler = async ({ request, fetch }) => {
 
   try {
     await lucia.deleteExpiredSessions();
+    Sentry.captureCheckIn({
+      checkInId,
+      monitorSlug: 'cleanup-cron',
+      status: 'ok',
+    });
     return json({ success: true }, { status: 200 });
   } catch (e) {
     console.error(e);
+    Sentry.captureCheckIn({
+      checkInId,
+      monitorSlug: 'cleanup-cron',
+      status: 'error',
+    });
     return json({ success: false, error: e }, { status: 500, statusText: "Internal Server Error" });
   }
 };

--- a/src/routes/api/internal/crons/minionprice/+server.ts
+++ b/src/routes/api/internal/crons/minionprice/+server.ts
@@ -1,10 +1,33 @@
 import { CRON_SECRET } from "$env/static/private";
 import { bulkUpdate, type BulkUpdateEntries } from "$lib/server/utilities";
+import * as Sentry from "@sentry/sveltekit";
 import { json } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 
+
+const checkInId = Sentry.captureCheckIn(
+  {
+    monitorSlug: 'minionprice-cron',
+    status: 'in_progress',
+  },
+  {
+    schedule: {
+      type: 'crontab',
+      value: '0 12 * * *',
+    },
+    checkinMargin: 0.2,
+    maxRuntime: 0.2,
+    timezone: 'Etc/UTC',
+  });
+
+
 export const GET: RequestHandler = async ({ request, fetch }) => {
   if (!CRON_SECRET || request.headers.get("Authorization") !== `Bearer ${CRON_SECRET}`) {
+    Sentry.captureCheckIn({
+      checkInId,
+      monitorSlug: 'minionprice-cron',
+      status: 'error',
+    });
     return json(
       { success: false, error: "Invalid Authorization header" },
       {
@@ -26,9 +49,20 @@ export const GET: RequestHandler = async ({ request, fetch }) => {
 
     await prisma.$transaction([bulkUpdate("Minion", bulkUpdates, "double precision")]);
 
+    Sentry.captureCheckIn({
+      checkInId,
+      monitorSlug: 'minionprice-cron',
+      status: 'ok',
+    });
+
     return json({ success: true }, { status: 200 });
   } catch (e) {
     console.error(e);
+    Sentry.captureCheckIn({
+      checkInId,
+      monitorSlug: 'minionprice-cron',
+      status: 'error',
+    });
     return json({ success: false, error: JSON.stringify(e) }, { status: 500, statusText: "Internal Server Error" });
   }
 };


### PR DESCRIPTION
This pull request updates the cron scripts to capture the check-in status during the cleanup and minionprice cron jobs. It adds code to capture the check-in status using the Sentry library. The check-in status is captured at the start and end of each cron job, and in case of any errors. This will provide better monitoring and error tracking for the cron jobs.