### PR TITLE
Enhance auction alert logic to check for existing chat

### DIFF
--- a/src/routes/(shared)/user/[user=username]/(protected)/chat/+page.svelte
+++ b/src/routes/(shared)/user/[user=username]/(protected)/chat/+page.svelte
@@ -63,9 +63,9 @@
     return auctions.map((auction) => JSON.parse(auction.content).id);
   });
 
-  // Only show the alert dialog if there are no auctions with the same ID in the chat
+  // Only show the alert dialog if there are no auctions with the same ID in the chat and the chat exists
   const showAuctionAlert = derived([auctionIds, chatSignal], ([$auctionIds, $chatSignal]) => {
-    if (!$chatSignal) return false;
+    if (!$chatSignal || !chatExists) return false;
     return !$auctionIds.includes($chatSignal.id);
   });
 


### PR DESCRIPTION
Improve the logic for displaying auction alerts by ensuring that the alert only shows if there are no auctions with the same ID in the chat and the chat exists.