### PR TITLE
Refactor database connection and remove Prisma Accelerate extension

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Database
 # Prisma Accelerate
-DATABASE_URL="prisma://accelerate.prisma-data.net/?api_key=__API_KEY__"
+DATABASE_URL="postgres://postgres:[password]@db.[your-supabase-project].supabase.co:5432/postgres"
 # Direct Supabase / Postgres connection
 DIRECT_DATABASE_URL="postgres://postgres:[password]@db.[your-supabase-project].supabase.co:5432/postgres"
 

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "@oslojs/oauth2": "^0.5.0",
     "@oslojs/webauthn": "^1.0.0",
     "@prisma/client": "5.21.1",
-    "@prisma/extension-accelerate": "^1.2.1",
     "@sentry/svelte": "^8.35.0",
     "@sentry/sveltekit": "^8.35.0",
     "@tiptap/core": "^2.9.1",
@@ -110,7 +109,7 @@
   },
   "engines": {
     "node": "^22",
-    "pnpm": "^9",
+    "pnpm": "^9 || ^10",
     "deno": "forbidden, use node instead",
     "npm": "forbidden, use pnpm instead",
     "yarn": "forbidden, use pnpm instead",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       '@prisma/client':
         specifier: 5.21.1
         version: 5.21.1(prisma@5.22.0)
-      '@prisma/extension-accelerate':
-        specifier: ^1.2.1
-        version: 1.2.1(@prisma/client@5.21.1(prisma@5.22.0))
       '@sentry/svelte':
         specifier: ^8.35.0
         version: 8.51.0(svelte@4.2.19)
@@ -1517,12 +1514,6 @@ packages:
 
   '@prisma/engines@5.22.0':
     resolution: {integrity: sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==}
-
-  '@prisma/extension-accelerate@1.2.1':
-    resolution: {integrity: sha512-QicnMeyqL226ilT3vvRsFAqPeIdqHGKR4c25CoK5zZ1tNIv8egfgpD1gCKqOGmfAz0pIKQnMuJU3eNg9KItC7A==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      '@prisma/client': '>=4.16.1'
 
   '@prisma/fetch-engine@5.22.0':
     resolution: {integrity: sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==}
@@ -5775,10 +5766,6 @@ snapshots:
       '@prisma/engines-version': 5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2
       '@prisma/fetch-engine': 5.22.0
       '@prisma/get-platform': 5.22.0
-
-  '@prisma/extension-accelerate@1.2.1(@prisma/client@5.21.1(prisma@5.22.0))':
-    dependencies:
-      '@prisma/client': 5.21.1(prisma@5.22.0)
 
   '@prisma/fetch-engine@5.22.0':
     dependencies:

--- a/src/lib/server/prisma.ts
+++ b/src/lib/server/prisma.ts
@@ -1,12 +1,10 @@
 import { PrismaClient } from "@prisma/client";
-import { withAccelerate } from "@prisma/extension-accelerate";
-
 declare global {
   // eslint-disable-next-line no-var
   var prisma: PrismaClient;
 }
 
-const prisma = global.prisma || new PrismaClient().$extends(withAccelerate());
+const prisma = global.prisma || new PrismaClient();
 global.prisma = prisma;
 
 export default prisma;

--- a/src/routes/(main)/+page.server.ts
+++ b/src/routes/(main)/+page.server.ts
@@ -23,11 +23,6 @@ export const load = (async () => {
             username: true
           }
         }
-      },
-      // @ts-expect-error - This isn't typed yet
-      cacheStrategy: {
-        ttl: 30,
-        swr: 60
       }
     }) as Promise<Seller[]>,
     minionTypes: prisma.minion.findMany({
@@ -39,10 +34,6 @@ export const load = (async () => {
       distinct: ["generator"],
       orderBy: {
         generator: "asc"
-      },
-      // @ts-expect-error - This isn't typed yet
-      cacheStrategy: {
-        ttl: 2629746 // 1 month
       }
     }),
     users: prisma.user.findMany({
@@ -50,40 +41,18 @@ export const load = (async () => {
         id: true,
         username: true
       },
-      // @ts-expect-error - This isn't typed yet
-      cacheStrategy: {
-        ttl: 86400, // 1 day
-        swr: 60 // 1 minute
-      },
       orderBy: {
         loggedInAt: "desc"
       }
     }),
     stats: {
-      users: prisma.user.count({
-        // @ts-expect-error - This isn't typed yet
-        cacheStrategy: {
-          ttl: 86400, // 1 day
-          swr: 60 // 1 minute
-        }
-      }),
-      auctions: prisma.auction.count({
-        // @ts-expect-error - This isn't typed yet
-        cacheStrategy: {
-          ttl: 30,
-          swr: 60
-        }
-      }),
+      users: prisma.user.count(),
+      auctions: prisma.auction.count(),
       chats: prisma.chat.count({
         where: {
           messages: {
             some: {}
           }
-        },
-        // @ts-expect-error - This isn't typed yet
-        cacheStrategy: {
-          ttl: 43200, // 12 hours
-          swr: 60
         }
       })
     }


### PR DESCRIPTION
Remove the Prisma Accelerate extension and simplify the cache strategy in the page server load, enhancing the database connection configuration.